### PR TITLE
Use code-style for ascii table in doc

### DIFF
--- a/doc/textobj-word-column.txt
+++ b/doc/textobj-word-column.txt
@@ -83,6 +83,7 @@ CHANGELOG                                       *textobj-word-column-changelog*
   should start and stop for columns with variable length words, and are
   smarter about when to do when whitespace is in the mix.
 
+>
   * Cursor position | vic Without Smart Boundaries | vic With Smart Boundaries
   ------------------+------------------------------+---------------------------
 
@@ -97,4 +98,4 @@ CHANGELOG                                       *textobj-word-column-changelog*
       abc   *omg              abc|    |omg                abc   | |omg
       abcdef omg              abc|def |omg                abcdef| |omg
       abc    omg              abc|    |omg                abc   | |omg
-
+<


### PR DESCRIPTION
Vimhelp uses || to show links (and conceals the characters). Delimit the
table as code so the bars show up as intended.
