### PR TITLE
Fix for shorter lines

### DIFF
--- a/plugin/textobj/word-column.vim
+++ b/plugin/textobj/word-column.vim
@@ -94,8 +94,9 @@ function! s:find_boundary_row(start_line, start_col, indent_level, step)
     let next_line      = current_line + a:step
     let non_blank      = getline(next_line) =~ "[^ \t]"
     let same_indent    = s:indent_level(next_line) == a:indent_level
+    let has_width      = getline(next_line) =~ '\%'.a:start_col.'v'
     let is_not_comment = ! s:is_comment(next_line, a:start_col)
-    if same_indent && non_blank && is_not_comment
+    if same_indent && non_blank && has_width && is_not_comment
       let current_line = next_line
     else
       return current_line

--- a/plugin/textobj/word-column.vim
+++ b/plugin/textobj/word-column.vim
@@ -9,8 +9,8 @@ function! TextObjWordBasedColumn(textobj)
   let stop_col        = virtcol("'>")
   let line_num        = line(".")
   let indent_level    = s:indent_level(".")
-  let start_line      = s:find_boundary_row(line_num, start_col, indent_level, -1)
-  let stop_line       = s:find_boundary_row(line_num, start_col, indent_level, 1)
+  let start_line      = s:find_boundary_row(line_num, col("'<"), start_col, indent_level, -1)
+  let stop_line       = s:find_boundary_row(line_num, col("'<"), start_col, indent_level, 1)
   let whitespace_only = s:whitespace_column_wanted(start_line, stop_line, cursor_col)
 
   if (exists("g:textobj_word_column_no_smart_boundary_cols"))
@@ -84,7 +84,7 @@ function! s:whitespace_column_wanted(start_line, stop_line, cursor_col)
   return 1
 endfunction
 
-function! s:find_boundary_row(start_line, start_col, indent_level, step)
+function! s:find_boundary_row(start_line, start_col, start_vcol, indent_level, step)
   let current_line = a:start_line
   let max_boundary = 0
   if a:step == 1
@@ -94,7 +94,7 @@ function! s:find_boundary_row(start_line, start_col, indent_level, step)
     let next_line      = current_line + a:step
     let non_blank      = getline(next_line) =~ "[^ \t]"
     let same_indent    = s:indent_level(next_line) == a:indent_level
-    let has_width      = getline(next_line) =~ '\%'.a:start_col.'v'
+    let has_width      = getline(next_line) =~ '\%'.a:start_vcol.'v'
     let is_not_comment = ! s:is_comment(next_line, a:start_col)
     if same_indent && non_blank && has_width && is_not_comment
       let current_line = next_line


### PR DESCRIPTION
With the cursor on `ab`, I get an invalid selection that extends to the `.` of the second line (and a beep when smart boundaries are used), instead of the expected selection of lines 3 + 4.

```
" Use real visual mode mappings to avoid the mapping delay when entering visual
" mode with "v".
xnoremap <silent> ab :<C-u>call TextObjWordBasedColumn("aw")<cr>
xnoremap <silent> aB :<C-u>call TextObjWordBasedColumn("aW")<cr>
```

This can be fixed by checking that there's actually a character at the start virtual column. The match for the exact column number also ensures that if the position is inside a Tab or in the middle of a double-width character, the selection will not be extended.

---

Addtionally, `synID()` needs the byte column, not virtual column.

This matters when there are multi-byte, unprintable, or Tab characters, in which cases the virtual (screen) column is not equal to the byte index.
